### PR TITLE
Simple linting tool - reports potential issues in model if provided DDL in liquibase sql format

### DIFF
--- a/liquilint/Dockerfile
+++ b/liquilint/Dockerfile
@@ -1,0 +1,15 @@
+FROM rocker/ropensci:latest
+
+#RUN rm -vfr /var/lib/apt/lists/*
+
+#RUN apt-get update && apt-get -y upgrade && apt-get install -y \
+	
+#RUN rm -rf /tmp/*.rds && \
+#	apt-get autoclean
+
+RUN install2.r --error \
+  argparser \
+  selectr
+
+WORKDIR /home/rstudio
+EXPOSE 8787

--- a/liquilint/Makefile
+++ b/liquilint/Makefile
@@ -1,0 +1,21 @@
+#!make
+
+PWD=$(shell pwd)
+DDL=https://raw.githubusercontent.com/DINA-Web/collections-data-model/master/src/main/resources/edu/harvard/huh/specify/datamodel/cco_poc/db/tables.sql
+
+.PHONY: all
+
+all: lint
+
+lint:
+	./lint_liquibase_sql.R -i $(DDL)
+
+help-lint:
+	./lint_liquibase_sql.R --help
+
+docker-lint:
+	@echo "Using Docker to execute command"
+	docker build . -t dina/liquilint
+	docker run -v $(PWD):/home/rstudio/lint -w /home/rstudio/lint \
+		dina/liquilint Rscript \
+		lint_liquibase_sql.R --input my_local_liquibase_ddl_file.sql

--- a/liquilint/README.md
+++ b/liquilint/README.md
@@ -1,0 +1,88 @@
+# liquilint
+
+This directory contains a tool for simple linting of liquibase DDL expressed in SQL from the command line. 
+
+Right now the tool is embryonic, so it does not support all rules suggested in the guidelines, it just checks for reserved words, expecting to be given input in [liquibase sql format](http://www.liquibase.org/documentation/sql_format.html), for example like using a text format that looks like this for each table and its fields:
+
+    --liquibase formatted sql
+    
+    --changeset nvoxland:1
+    create table test1 (
+        id int primary key,
+        name varchar(255)
+    );
+    
+In the example above the liniting would report one of the fields to clash with the list of reserved words.
+
+## Usage
+
+The `Makefile` shows some ways to use `lint_liquibase_sql.R` from the commandline:
+
+		# example invocation using the default DDL (url at top of Makefile, can be edited)
+		make
+		
+		# example using other DDL (from external public url)
+		make lint DDL=https://raw.githubusercontent.com/chicoreus/cco_poc/master/src/main/resources/edu/harvard/huh/specify/datamodel/cco_full/db/tables.sql
+
+		# example invocation using Docker (see details in Makefile)
+		make docker-lint
+
+		# example invocation using local file
+		make lint DDL=my_local_liquibase_ddl_file.sql
+
+This means the DDL / schema can be expressed in liquiqbase sql, say named to my\_local\_liquibasei\_ddl\_file.sql with content such as in the example below, with DDL describing a couple of example tables:
+
+    CREATE TABLE biologicalindividual (
+      -- Definition: An individual organism that is specifically known and identified and known as that individual to have been observed or sampled.
+      biologicalindividual_id bigint not null primary key auto_increment, -- surrogate numeric primary key
+      biologicalindividual_guid varchar(900), -- guid for the biological individual darwinsw:{term}
+      name varchar(900), -- human readable identifier for the biological individual
+      modified_by_agent_id bigint not null default 1, -- agent to last modify row in this table
+      remarks text
+    )
+
+    CREATE TABLE catalogeditem (
+      -- Definition: the application of a catalog number out of some catalog number series.
+      catalogeditem_id bigint not null primary key auto_increment, -- surrogate numeric primary key
+      catalognumberseries_id bigint not null, -- The catalog number series from which the catalog_number comes.
+      catalog_number varchar(255) not null,
+      date_cataloged_eventdate_id bigint,
+      cataloger_agent_id bigint,  -- The agent who cataloged the cataloged item
+      accession_id bigint not null,  -- The accession in which ownership of this cataloged item was taken
+      collection_id bigint not null,  -- The collection within which this item is cataloged (catalog number series doesn't uniquely idenitify collections).
+      modified_by_agent_id bigint not null default 1 -- agent to last modify row in this table
+    )
+
+The tool can then lint this content. Since two regexpes are used in the tool to extract table names (`"create table (\\w+) [(]"`) and field names (`"\\s+ (\\w+) (\\w+).*"`) it can be expressed even shorter in a text file as long as tables can be extracted using those patterns.
+
+## Report
+
+The simple linting tool reports if any tables or columns/fields have names that conflict with the list of reserved words from [Drupal's list of SQL reserved words](https://www.drupal.org/docs/develop/coding-standards/list-of-sql-reserved-words).
+
+As an example, a report can look like this when running `make lint DDL=my_local_liquibase_ddl_file.sql:
+
+    Inappropriate fields/columns:
+    	name
+
+When using a bigger more full fledged model as input, the result can look like this:
+
+    Inappropriate tables:
+    	storage
+    Inappropriate fields/columns:
+    	name
+    	table_name
+    	value
+    	status
+    	method
+    	source
+    	number
+    	section
+    	role
+    	prefix
+    	type
+    	text
+    	foreign
+    	language
+    	scope
+    	action
+

--- a/liquilint/lint_liquibase_sql.R
+++ b/liquilint/lint_liquibase_sql.R
@@ -1,0 +1,110 @@
+#!/usr/bin/Rscript
+
+import <- function(packages) {
+  # Installs missing R package(s), if required from SUNET repo    
+  kSUNET <- "http://ftp.sunet.se/mirror/CRAN/"  
+  
+  getPackage <- function(package) {
+    available <- suppressPackageStartupMessages(
+      suppressMessages(suppressWarnings(
+        require(package, character.only = TRUE, 
+                quietly = TRUE, warn.conflicts = FALSE))))
+    if (!available) {
+      # the package is not available, so try to install and load it
+      res <- tryCatch({ 
+        install.packages(package, repos = kSUNET)
+        loaded <- suppressPackageStartupMessages(
+          suppressMessages(suppressWarnings(
+            require(package, character.only = TRUE, 
+                    quietly = TRUE, warn.conflicts = FALSE))))
+      }, error = function(e) {
+        loaded <- FALSE
+      })
+    } else loaded <- TRUE
+    return(loaded)
+  }  
+  res <- sapply(packages, getPackage)  
+}
+
+                                 
+import(c("rvest", "httr", "readr", "dplyr", "argparser", "selectr"))
+
+p <- arg_parser(paste0("Case insensitive scan for reserved", 
+  "words in liquibase sql statements...."))
+
+p <- add_argument(p, "--stopwords", 
+  help = "input file or url with liquibase sql",
+  default = paste0("https://www.drupal.org/docs/develop/",
+    "coding-standards/list-of-sql-reserved-words"))
+
+p <- add_argument(p, "--input", 
+  help = "file or url with checklist of stopwords", 
+  default = paste0("https://raw.githubusercontent.com/chicoreus",
+    "/cco_poc/master/src/main/resources/edu/harvard/huh/",
+    "specify/datamodel/cco_full/db/tables.sql"))
+
+p <- add_argument(p, "--verbose", 
+  help = "provide more details",
+  flag = TRUE)
+
+argv <- parse_args(p)
+
+if (argv$help) {
+  print(p)
+  if (!interactive()) q(status = 0)
+}
+
+if (argv$verbose) {
+  message("Using stopwords in ", argv$stopwords)
+  message("Using input liquibase sql in ", argv$input)
+}
+
+words <- 
+  content(GET(argv$stopwords)) %>%
+  html_nodes(css = "ol li") %>% 
+  html_text
+
+sql <- tolower(read_lines(argv$input))
+
+re_tables <- "create table (\\w+) [(]"
+re_fields <- "\\s+ (\\w+) (\\w+).*"
+
+parse_liquibase_sql <- function(re, sql) {
+  gsub(re, "\\1", grep(re, sql, value = TRUE))
+}
+
+tables <- parse_liquibase_sql(re_tables, sql)
+fields <- parse_liquibase_sql(re_fields, sql)
+terms <- unlist(strsplit(c(tables, fields), "_"))
+
+if (argv$verbose)
+  message(paste0("Beginning scan of table names, ", 
+     "field/column names and terms ", 
+     "(splitting composite names by '_')"))
+
+find_stopwords <- function(x) {
+  intersect(tolower(x), tolower(words))
+}
+
+stop_tables <- find_stopwords(tables)
+stop_fields <- find_stopwords(fields)
+stop_terms <- find_stopwords(terms)
+
+# if (argv$verbose) {
+#   message("Using stopwords: ",
+#     paste(collapse = ", ", tolower(words)), "\n")
+# }
+
+if (length(stop_tables) > 0)
+  message("Inappropriate tables:\n\t", 
+          paste(collapse = "\n\t", stop_tables))
+
+if (length(stop_fields) > 0)
+  message("Inappropriate fields/columns:\n\t", 
+          paste(collapse = "\n\t", stop_fields))
+
+if (length(stop_terms) > 0 & argv$verbose)
+  message("Inappropriate terms in composite strings:\n\t", 
+          paste(collapse = "\n\t", stop_terms))
+
+if (argv$verbose) message("Done")

--- a/liquilint/my_local_liquibase_ddl_file.sql
+++ b/liquilint/my_local_liquibase_ddl_file.sql
@@ -1,0 +1,20 @@
+CREATE TABLE biologicalindividual (
+  -- Definition: An individual organism that is specifically known and identified and known as that individual to have been observed or sampled.
+  biologicalindividual_id bigint not null primary key auto_increment, -- surrogate numeric primary key
+  biologicalindividual_guid varchar(900), -- guid for the biological individual darwinsw:{term}
+  name varchar(900), -- human readable identifier for the biological individual
+  modified_by_agent_id bigint not null default 1, -- agent to last modify row in this table
+  remarks text
+)
+
+CREATE TABLE catalogeditem (
+  -- Definition: the application of a catalog number out of some catalog number series.
+  catalogeditem_id bigint not null primary key auto_increment, -- surrogate numeric primary key
+  catalognumberseries_id bigint not null, -- The catalog number series from which the catalog_number comes.
+  catalog_number varchar(255) not null,
+  date_cataloged_eventdate_id bigint,
+  cataloger_agent_id bigint,  -- The agent who cataloged the cataloged item
+  accession_id bigint not null,  -- The accession in which ownership of this cataloged item was taken
+  collection_id bigint not null,  -- The collection within which this item is cataloged (catalog number series doesn't uniquely idenitify collections).
+  modified_by_agent_id bigint not null default 1 -- agent to last modify row in this table
+)


### PR DESCRIPTION
Provide a simple linting tool with some basic functionality to report inappropriate words that may appear in field or column names in input provided as liquibase-formatted DDL in SQL format.